### PR TITLE
Simplify PPPoE credentials for KPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,8 @@ If you are a customer of KPN, you can set up the WAN connection as follows:
 3. Enable **VLAN ID** and set it to the Internet VLAN of your ISP (VLAN6 for
    KPN).
 4. Set **IPv4 Connection** to _PPPoE_.
-5. For KPN, **Username** should be set to `xx-xx-xx-xx-xx-xx@internet` where
-   the `xx-xx-xx-xx-xx-xx` is replaced by the MAC address of your modem, with
-   the semicolons (":") replaced with dashes ("-").
-6. For KPN, **Password** should be set to `ppp`.
+5. For KPN, **Username** should be set to `internet`.
+6. For KPN, **Password** should be set to `internet`.
 
 ## Configuring Internal LAN
 


### PR DESCRIPTION
Installed the 1.11.x firmware a few days ago on my UDM Pro and today installed your IGMP proxy script to finally be able to remove the KPN modem from my setup. It worked flawlessly! The instructions can be simplified a bit however, because as far as I understand it KPN allows any username/password combination for PPPoE. But as an example they state to use internet/internet. Tried that, and it works. Easier than having to look up / type the MAC address of your modem.

Thank you for your efforts!