### PR TITLE
Enable restart on failure

### DIFF
--- a/debian/udm-iptv.service
+++ b/debian/udm-iptv.service
@@ -7,6 +7,8 @@ Type=simple
 EnvironmentFile=/etc/udm-iptv.conf
 ExecStart=/usr/lib/udm-iptv/udm-iptv start
 ExecStop=/usr/lib/udm-iptv/udm-iptv stop
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add a restart on failure to the service. Sometimes after reboot or network is down. The iptv network is not created or the igmpproxy is nto started