### PR TITLE
feat: added another IP range for Init7 (Zurich city)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ configure the package. Below is a useful list of configuration values for variou
 |    Telekom (DE) |    0     | 232.0.0.0/16 87.141.0.0/16                                            | Telekom uses VLAN 7 for both internet and IPTV                                                             |
 |  MagentaTV (DE) |    0     | 224.0.0.0/4 87.141.0.0/16 193.158.0.0/15                              | [Custom configuration](https://github.com/fabianishere/udm-iptv/issues/2#issuecomment-1007413230) required |
 |   Swisscom (CH) |    0     | 195.186.0.0/16 213.3.72.0/24 224.0.0.0/4                              |                                                                                                            |
-|      Init7 (CH) |    0     | 224.0.0.0/8 239.0.0.0/8                                               |                                                                                                            |
+|      Init7 (CH) |    0     | 224.0.0.0/8 239.0.0.0/8 77.109.128.0/19                                               |                                                                                                            |
 |        MEO (PT) |    0     | 10.159.0.0/16 10.173.0.0/16 194.65.46.0/23 213.13.16.0/20 224.0.0.0/4 |                                                                                                            |
 |         BT (GB) |    0     | 224.0.0.0/4 109.159.247.0/24                                          | [Custom configuration](https://github.com/fabianishere/udm-iptv/issues/2#issuecomment-929968478) required  |
 |    Vivo SP (BR) |   20     | 172.28.0.0/14  201.0.52.0/23  200.161.71.0/24  177.16.0.0/16          | Set DNS servers to 177.16.30.67 and 177.16.30.7 for internal IPTV network |


### PR DESCRIPTION
at least for me it was necessary to add this additional IP range. I already had IP TV working on a Unifi Secure Gateway some time ago and basically re-used the config from that time (as the "IP Group" has still been there lying around until it hopefully worked again :) )

Thanks for your work!
I do think I understand two or three things about network and then suddenly there is some new "black magic" .. :)

Interesting though, that my VLC currently stutters all few seconds - maybe that's just an Issue with my local machine .. gona update all drivers etc now.. but maybe you have a clue what this could be (just opened VLC and all few seconds a line in the "mid" gets replicated to the bottom (stretched?) - and after a quick stutter, image looks good again - and then it repeats all 5-10 seconds)