### PR TITLE
Support static IP assignment

### DIFF
--- a/debian/config
+++ b/debian/config
@@ -73,6 +73,7 @@ if [ -e $CONFIGFILE ]; then
     db_set udm-iptv/wan-vlan-separate "$([ "$IPTV_WAN_INTERFACE" = 0 ] && echo "false" || echo "true")"
     db_set udm-iptv/wan-vlan "$IPTV_WAN_VLAN"
     db_set udm-iptv/wan-vlan-interface "$IPTV_WAN_VLAN_INTERFACE"
+    db_set udm-iptv/wan-vlan-mac "$IPTV_WAN_VLAN_MAC"
 
     db_set udm-iptv/wan-ranges "$(echo "$IPTV_WAN_RANGES" | tr -s ' ' ',')"
     db_set udm-iptv/wan-dhcp-options "$IPTV_WAN_DHCP_OPTIONS"
@@ -130,24 +131,27 @@ while true; do
     4)  # Configure VLAN interface name
         db_input low udm-iptv/wan-vlan-interface || true
         ;;
-    5)  # Configure WAN ranges
+    5)  # Configure MAC address of VLAN interface
+        db_input low udm-iptv/wan-vlan-mac || true
+        ;;
+    6)  # Configure WAN ranges
         db_input high udm-iptv/wan-ranges || true
         ;;
-    6)  # Configure DHCP options
+    7)  # Configure DHCP options
         db_input high udm-iptv/wan-dhcp-options || true
         ;;
-    7)  # Select LAN interfaces
+    8)  # Select LAN interfaces
         db_subst udm-iptv/lan-interfaces choices "$(_if_inet_list | sed ':a;N;s/\n/, /;ba')"
         db_subst udm-iptv/lan-interfaces choices_c "$(find /sys/class/net -name "br*" -exec basename {} \; | sort | sed ':a;N;s/\n/, /;ba')"
         db_input high udm-iptv/lan-interfaces || true
         ;;
-    8)  # Configure igmpproxy
+    9)  # Configure igmpproxy
         db_beginblock
         db_input low udm-iptv/igmpproxy-quickleave || true
         db_input medium udm-iptv/igmpproxy-debug || true
         db_endblock
         ;;
-    9)  # Complete configuration
+    10)  # Complete configuration
         exit 0
         ;;
     *)  # unknown state

--- a/debian/config
+++ b/debian/config
@@ -76,7 +76,9 @@ if [ -e $CONFIGFILE ]; then
     db_set udm-iptv/wan-vlan-mac "$IPTV_WAN_VLAN_MAC"
 
     db_set udm-iptv/wan-ranges "$(echo "$IPTV_WAN_RANGES" | tr -s ' ' ',')"
+    db_set udm-iptv/wan-dhcp "$IPTV_WAN_DHCP_ENABLE"
     db_set udm-iptv/wan-dhcp-options "$IPTV_WAN_DHCP_OPTIONS"
+    db_set udm-iptv/wan-static-ip "$IPTV_WAN_STATIC_IP"
 
     db_set udm-iptv/lan-interfaces "$(echo "$IPTV_LAN_INTERFACES" | tr -s ' ' ',')"
 
@@ -115,6 +117,8 @@ while true; do
         if [ "$RET" = false ]; then
             # IPTV traffic is on native VLAN
             db_set udm-iptv/wan-vlan 0
+            # Disable DHCP by default
+            db_set udm-iptv/wan-dhcp false
 
             db_get udm-iptv/wan-port
             db_subst udm-iptv/wan-interface choices "$(_if_inet_list_upper "/sys/class/net/$RET" | sed ':a;N;s/\n/, /;ba')"
@@ -124,12 +128,19 @@ while true; do
             db_get udm-iptv/wan-port
             db_set udm-iptv/wan-interface "$RET"
 
+            # Enable DHCP by default
+            db_set udm-iptv/wan-dhcp true
+
             # Configure VLAN ID
             db_input high udm-iptv/wan-vlan || true
         fi
         ;;
-    4)  # Configure VLAN interface name
-        db_input low udm-iptv/wan-vlan-interface || true
+    4)
+        db_get udm-iptv/wan-vlan-separate
+        if [ "$RET" = true ]; then
+            # Configure VLAN interface name
+            db_input low udm-iptv/wan-vlan-interface || true
+        fi
         ;;
     5)  # Configure MAC address of VLAN interface
         db_input low udm-iptv/wan-vlan-mac || true
@@ -137,21 +148,29 @@ while true; do
     6)  # Configure WAN ranges
         db_input high udm-iptv/wan-ranges || true
         ;;
-    7)  # Configure DHCP options
-        db_input high udm-iptv/wan-dhcp-options || true
+    7)  # Override DHCP
+        db_input low udm-iptv/wan-dhcp || true
         ;;
-    8)  # Select LAN interfaces
+    8)  # Configure DHCP options
+        db_get udm-iptv/wan-dhcp
+        if [ "$RET" = true ]; then
+            db_input high udm-iptv/wan-dhcp-options || true
+        else
+            db_input low udm-iptv/wan-static-ip || true
+        fi
+        ;;
+    9)  # Select LAN interfaces
         db_subst udm-iptv/lan-interfaces choices "$(_if_inet_list | sed ':a;N;s/\n/, /;ba')"
         db_subst udm-iptv/lan-interfaces choices_c "$(find /sys/class/net -name "br*" -exec basename {} \; | sort | sed ':a;N;s/\n/, /;ba')"
         db_input high udm-iptv/lan-interfaces || true
         ;;
-    9)  # Configure igmpproxy
+    10)  # Configure igmpproxy
         db_beginblock
         db_input low udm-iptv/igmpproxy-quickleave || true
         db_input medium udm-iptv/igmpproxy-debug || true
         db_endblock
         ;;
-    10)  # Complete configuration
+    11)  # Complete configuration
         exit 0
         ;;
     *)  # unknown state

--- a/debian/postinst
+++ b/debian/postinst
@@ -57,8 +57,18 @@ fi
 db_get udm-iptv/wan-ranges
 replace_conf "$tmpconf" "IPTV_WAN_RANGES" "$(echo "$RET" | tr ',' ' ')"
 
+db_get udm-iptv/wan-dhcp
+replace_conf "$tmpconf" "IPTV_WAN_DHCP" "$RET"
+
 db_get udm-iptv/wan-dhcp-options
 replace_conf "$tmpconf" "IPTV_WAN_DHCP_OPTIONS" "$RET"
+
+db_get udm-iptv/wan-static-ip
+if [ -n "$RET" ]; then
+    replace_conf "$tmpconf" "IPTV_WAN_STATIC_IP" "$RET"
+else
+    remove_conf "$tmpconf" "IPTV_WAN_STATIC_IP"
+fi
 
 db_get udm-iptv/lan-interfaces
 replace_conf "$tmpconf" "IPTV_LAN_INTERFACES" "$(echo "$RET" | tr ',' ' ')"

--- a/debian/postinst
+++ b/debian/postinst
@@ -24,6 +24,16 @@ replace_conf() {
     fi
 }
 
+# Remove a debconf answer from a configuration file with the syntax of
+# /etc/udm-iptv.conf
+remove_conf() {
+    file="$1"
+    setting="$2"
+    if grep -q "^${setting}=" "$file"; then
+        sed -i -re "/^${setting}=.*$/d" "$file"
+    fi
+}
+
 tmpconf=$(mktemp -t iptv.XXXX.conf)
 # Copy original configuration into temp file
 cp /etc/udm-iptv.conf "$tmpconf" || true
@@ -36,6 +46,13 @@ replace_conf "$tmpconf" "IPTV_WAN_VLAN" "$RET"
 
 db_get udm-iptv/wan-vlan-interface
 replace_conf "$tmpconf" "IPTV_WAN_VLAN_INTERFACE" "$RET"
+
+db_get udm-iptv/wan-vlan-mac
+if [ -n "$RET" ]; then
+    replace_conf "$tmpconf" "IPTV_WAN_VLAN_MAC" "$RET"
+else
+    remove_conf "$tmpconf" "IPTV_WAN_VLAN_MAC"
+fi
 
 db_get udm-iptv/wan-ranges
 replace_conf "$tmpconf" "IPTV_WAN_RANGES" "$(echo "$RET" | tr ',' ' ')"

--- a/debian/templates
+++ b/debian/templates
@@ -34,10 +34,19 @@ Description: IP ranges from which the IPTV traffic originates:
 Type: string
 Default: 213.75.0.0/16, 217.166.0.0/16
 
+Template: udm-iptv/wan-dhcp
+Description: Obtain IP address for IPTV interface via DHCP?
+Type: boolean
+
 Template: udm-iptv/wan-dhcp-options
 Description: DHCP options to send when requesting an IP address:
 Type: string
 Default: -O staticroutes -V IPTV_RG
+
+Template: udm-iptv/wan-static-ip
+Description: Static IP address to assign to IPTV interface:
+Type: string
+Default:
 
 Template: udm-iptv/lan-interfaces
 Description: LAN interfaces on which IPTV should be made available:

--- a/debian/templates
+++ b/debian/templates
@@ -24,6 +24,11 @@ Description: Name of the IPTV VLAN interface:
 Type: string
 Default: iptv
 
+Template: udm-iptv/wan-vlan-mac
+Description: Custom MAC address for the IPTV VLAN interface:
+Type: string
+Default:
+
 Template: udm-iptv/wan-ranges
 Description: IP ranges from which the IPTV traffic originates:
 Type: string

--- a/udm-iptv
+++ b/udm-iptv
@@ -54,10 +54,16 @@ _network_setup() {
         # Bring VLAN interface up
         ip link set dev "$IPTV_WAN_VLAN_INTERFACE" up
 
-        echo "Obtaining IP address for VLAN interface"
+        if [ "$IPTV_WAN_DHCP_ENABLE" != "false" ]; then
+            echo "Obtaining IP address for VLAN interface"
 
-        # Obtain IP address for VLAN interface
-        udhcpc -b -R -p /var/run/udhcpc."$IPTV_WAN_VLAN_INTERFACE".pid -s "$(dirname "$0")"/udhcpc.hook -i "$IPTV_WAN_VLAN_INTERFACE" $IPTV_WAN_DHCP_OPTIONS
+            # Obtain IP address for VLAN interface
+            udhcpc -b -R -p /var/run/udhcpc."$IPTV_WAN_VLAN_INTERFACE".pid -s "$(dirname "$0")"/udhcpc.hook -i "$IPTV_WAN_VLAN_INTERFACE" $IPTV_WAN_DHCP_OPTIONS
+        fi
+    fi
+
+    if [ "$IPTV_WAN_DHCP_ENABLE" != "false" ] && [ -n "$IPTV_WAN_STATIC_IP" ]; then
+        ip -4 addr change "$IPTV_WAN_STATIC_IP" dev "$target"
     fi
 
     echo "NATing IPTV network ranges (if necessary)"


### PR DESCRIPTION
This pull request adds support for assigning a static IP address to the IPTV interface (instead of requiring DHCP). This functionality is necessary for some providers, which require the user to manually set an IP address.

See for example: https://github.com/fabianishere/udm-iptv/discussions/86