### PR TITLE
Add profile for PostTV (LU)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ popular IPTV providers. Below is a list of supported IPTV providers:
 |        BT |   GB    | Yes                                                                                                         |
 |   Vivo SP |   BR    | Yes                                                                                                         |
 |   Telenor |   NO    | Yes                                                                                                         |
+|    PostTV |   LU    | Yes                                                                                                         |
 
 If your ISP is not supported, you may select the _Custom_ profile, which allows
 you manually configure the package to your needs. 

--- a/debian/config
+++ b/debian/config
@@ -59,6 +59,7 @@ _list_profiles() {
     echo "bt", "BT (GB)"
     echo "telenor", "Telenor (NO)"
     echo "vivo", "Vivo SP (BR)"
+    echo "posttv", "PostTV (LU)"
 }
 
 # Obtain the board name of the device running the installation script

--- a/profiles/posttv.profile
+++ b/profiles/posttv.profile
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+# Profile for PostTV (LU)
+#
+# Copyright (C) 2022 Fabian Mastenbroek.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+db_get udm-iptv/wan-port
+db_set udm-iptv/wan-interface "$RET"
+
+db_set udm-iptv/wan-vlan 0
+db_set udm-iptv/wan-ranges "172.19.9.0/24"
+db_set udm-iptv/wan-dhcp false
+db_set udm-iptv/wan-static-ip "10.20.30.1/24"


### PR DESCRIPTION
This change adds a new profile for the IPTV provider PostTV from
Luxembourg. This provider requires additional firewall configuration.

See https://github.com/fabianishere/udm-iptv/discussions/86#discussioncomment-2345968
for more information.