### PR TITLE
Overwrite actual file if config file is symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,13 @@ On the UniFi Dream Machine (Pro), use `unifi-os shell` to enter UniFi OS from
 within UbiOS.
 ```bash
 # Download udm-iptv package
-curl -O -L https://github.com/fabianishere/udm-iptv/releases/download/v2.1.3/udm-iptv_2.1.3_all.deb
+curl -O -L https://github.com/fabianishere/udm-iptv/releases/download/v2.1.4/udm-iptv_2.1.4_all.deb
 # Download a recent igmpproxy version
 curl -O -L http://ftp.debian.org/debian/pool/main/i/igmpproxy/igmpproxy_0.3-1_arm64.deb
 # Update APT sources and install dialog package for interactive install
 apt update && apt install dialog
 # Install udm-iptv and igmpproxy
-apt install ./igmpproxy_0.3-1_arm64.deb ./udm-iptv_2.1.3_all.deb
+apt install ./igmpproxy_0.3-1_arm64.deb ./udm-iptv_2.1.4_all.deb
 ```
 
 It may be possible that `apt` reports a warning after installation (like shown below),
@@ -215,8 +215,8 @@ of the package and installing it via `apt`. The service should automatically
 restart after upgrading.
 
 ```bash
-curl -O -L https://github.com/fabianishere/udm-iptv/releases/download/v2.1.3/udm-iptv_2.1.3_all.deb
-apt install ./udm-iptv_2.1.3_all.deb 
+curl -O -L https://github.com/fabianishere/udm-iptv/releases/download/v2.1.4/udm-iptv_2.1.4_all.deb
+apt install ./udm-iptv_2.1.4_all.deb 
 ```
 
 ### Removal

--- a/README.md
+++ b/README.md
@@ -168,19 +168,28 @@ If you experience any issues while setting up the service, please visit the
 [Troubleshooting](#troubleshooting-and-known-issues) section.
 
 ### Ensuring Installation across Firmware Updates
-On certain UniFi devices, such as the UniFi Dream Machine SE, you may need to
-update the device configuration to have the installation of the udm-iptv 
-package persist across firmware updates. Update `/etc/default/ubnt-dpkg-cache` 
-as follows (_only_ if it exists):
+
+To ensure your installation remains persistent across firmware updates, you may
+need to perform some manual steps which are described below.
+
+Even so, **please remember to make a backup of your configuration before a 
+firmware update**. Changes in Ubiquiti's future firmware (flashing process)
+might potentially cause your configuration to be lost.
+
+#### UniFi Dream Machine (Pro)
+Custom packages on the UniFi Dream Machine (Pro) are re-installed after a firmware
+updates, but custom configuration is lost. To ensure your configuration remains
+persistent, move the configuration file to a persistent location and create a symlink:
 
 ```bash
-sed -e '/^DPKG_CACHE_UBNT_PKGS+=" udm-iptv igmpproxy dialog"/{:a;n;ba;q}' -e '$aDPKG_CACHE_UBNT_PKGS+=" udm-iptv igmpproxy dialog"' -i /etc/default/ubnt-dpkg-cache
+mv /etc/udm-iptv /mnt/persistent
+ln -sf /mnt/persistent/udm-iptv.conf /etc/udm-iptv.conf
 ```
+Make sure to re-create the symlink after a firmware upgrade.
 
-If you do not perform this step, you will need to re-install the package after a
-firmware update. Note that your configuration might be lost across firmware
-updates, as a consequence of Ubiquiti's firmware flashing process ([#49](https://github.com/fabianishere/udm-iptv/issues/49)).
-**Please make a backup of your configuration before a firmware update**.
+#### UniFi Dream Machine SE and UniFi Dream Router
+It is currently not possible to persist the installation across firmware updates
+(see #120). Your configuration should remain, so only re-installation is necessary.
 
 ### Configuration
 You can modify the configuration of the service interactively using `dpkg-reconfigure -p medium udm-iptv`.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+udm-iptv (2.1.4) stable; urgency=medium
+
+  * Overwrite actual file if config file is symlink
+
+ -- Fabian Mastenbroek <mail.fabianm@gmail.com>  Sat, 16 Apr 2022 12:15:00 +0100
+
 udm-iptv (2.1.3) stable; urgency=high
 
   * Fix script for users that do not use watch functionality

--- a/debian/postinst
+++ b/debian/postinst
@@ -34,9 +34,11 @@ remove_conf() {
     fi
 }
 
+CONFIGFILE=/etc/udm-iptv.conf
 tmpconf=$(mktemp -t iptv.XXXX.conf)
+
 # Copy original configuration into temp file
-cp /etc/udm-iptv.conf "$tmpconf" || true
+cp "$CONFIGFILE" "$tmpconf" || true
 
 db_get udm-iptv/wan-interface
 replace_conf "$tmpconf" "IPTV_WAN_INTERFACE" "$RET"
@@ -88,7 +90,7 @@ db_get udm-iptv/igmpproxy-debug
 replace_conf "$tmpconf" "IPTV_IGMPPROXY_DEBUG" "$RET"
 
 # Replace file with updated configuration
-mv "$tmpconf" /etc/udm-iptv.conf
+mv "$tmpconf" "$(readlink -f "$CONFIGFILE")"
 
 #DEBHELPER#
 


### PR DESCRIPTION
This change updates the post installation script to not overwrite the
config file located at /etc/udm-iptv.conf if it is a symlink. Instead,
the symlink is resolved and the contents of the actual config file is
overwritten.