### PR TITLE
Add support for improxy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   build:
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-20.04]
     if: ${{ !contains(github.event.head_commit.message, 'skip ci') }}
     steps:
       - name: Checkout Sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-20.04]
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
             *.dsc
   release:
     name: Publish Release
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-20.04]
     needs: build
     steps:
       - name: Checkout Sources
@@ -48,12 +48,12 @@ jobs:
         run: |
           ref="${{ github.ref}}"
           release_name=${ref#"refs/tags/"}
-          echo "::set-output name=release::$release_name"
+          echo "release::$release_name" >> $GITHUB_OUTPUT
           changelog=$(dpkg-parsechangelog -c 1 -l debian/changelog)
           changelog="${changelog//'%'/'%25'}"
           changelog="${changelog//$'\n'/'%0A'}"
           changelog="${changelog//$'\r'/'%0D'}"
-          echo "::set-output name=changelog::$changelog"
+          echo "changelog<<EOF\n$changelog\nEOF" >> $GITHUB_OUTPUT
       - name: Create Release
         uses: softprops/action-gh-release@v1
         env:

--- a/README.md
+++ b/README.md
@@ -98,12 +98,6 @@ additional DHCP options. You can add these DHCP options as follows:
    order to reduce interference of other devices on the network.
 3. Enable **Advanced Configuration > IGMP Snooping**, so IPTV traffic is only
    sent to devices that should receive it.
-4. Go to **DHCP > Custom DHCP Option** and add the following options:
-
-   | Name       | Code | Type       | Value               |
-   |------------|:----:|------------|---------------------|
-   | IPTV-Class |  60  | Text       | IPTV_RG             |
-
 
 ## Configuring Helper Tool
 

--- a/README.md
+++ b/README.md
@@ -148,27 +148,30 @@ If you experience any issues while setting up the service, please visit the
 
 ### Ensuring Installation across Firmware Updates
 
-To ensure your installation remains persistent across firmware updates, you may
+To ensure your installation remains working across firmware updates, you may
 need to perform some manual steps which are described below.
 
-Even so, **please remember to make a backup of your configuration before a 
+**Please remember to make a backup of your configuration before a 
 firmware update**. Changes in Ubiquiti's future firmware (flashing process)
 might potentially cause your configuration to be lost.
 
 #### UniFi Dream Machine (Pro)
-Custom packages on the UniFi Dream Machine (Pro) are re-installed after a firmware
-updates, but custom configuration is lost. To ensure your configuration remains
-persistent, move the configuration file to a persistent location and create a symlink:
+Custom packages on the UniFi Dream Machine (Pro) are re-installed after 
+firmware upgrades, but custom configuration is lost. 
+
+You may move the configuration file to a persistent location and copy back
+the configuration after the firmware upgrade.
 
 ```bash
-mv /etc/udm-iptv.conf /mnt/persistent
-ln -sf /mnt/persistent/udm-iptv.conf /etc/udm-iptv.conf
+# Copy to persistent storage
+cp /etc/udm-iptv.conf /mnt/persistent/udm-iptv.conf
+# Copy from persistent storage
+cp /mnt/persistent/udm-iptv.conf /etc/udm-iptv.conf
 ```
-Make sure to re-create the symlink after a firmware upgrade.
 
 #### UniFi Dream Machine SE and UniFi Dream Router
 It is currently not possible to persist the installation across firmware updates
-(see #120). Your configuration should remain, so only re-installation is necessary.
+(see [#120](https://github.com/fabianishere/udm-iptv/issues/120)). Your configuration should remain, so only re-installation is necessary.
 
 ### Configuration
 You can modify the configuration of the service interactively using `dpkg-reconfigure -p medium udm-iptv`.

--- a/README.md
+++ b/README.md
@@ -56,13 +56,7 @@ the [following guide](https://github.com/basmeerman/unifi-usg-kpn).
 Make sure you check the following prerequisites before trying the other steps:
 
 1. The kernel on your UniFi device must support multicast routing
-   in order to support IPTV:
-    - **UniFi Dream Machine (Pro)**: Multicast routing is supported natively in the stock kernel since
-   [firmware version 1.11](https://community.ui.com/releases/UniFi-OS-Dream-Machines-1-11-0/eef95803-6976-499b-9169-bf6dfbbcc209). 
-   If you for some reason cannot use firmware v1.11+, see [udm-kernel](https://github.com/fabianishere/udm-kernel)
-   for a kernel that supports multicast routing for older firmware versions of the UDM/P.
-    - **UniFi Dream Machine SE**: You need firmware version 2.3.7+ for multicast routing support.
-    - **UniFi Dream Router**: Multicast routing is supported by the default firmware.
+   in order to support IPTV. Please upgrade to the latest firmware.
 2. The switches in-between the IPTV decoder and the UniFi device should have IGMP
    snooping enabled. They do not need to be from Ubiquiti necessarily.
 3. The FTTP NTU (or any other type of modem) of your ISP must be connected to
@@ -218,7 +212,10 @@ instructions before opening a discussion.
 2. **Check if IPTV traffic is forwarded to the right VLAN**  
    Make sure that you have configured `IPTV_LAN_INTERFACES` correctly to forward
    to right interfaces (e.g., `br4` for VLAN 4).
-3. **Check if your issue has been reported already**  
+3. **Check if your kernel supports multicast routing**  
+   If `MRT_INIT failed; Errno(92): Protocol not available` appears in 
+   diagnostics, your kernel does not support multicast routing.
+4. **Check if your issue has been reported already**  
    Use the GitHub search functionality to check if your issue has already been
    reported before.
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ started.
 If you experience any issues while setting up the service, please visit the
 [Troubleshooting](#troubleshooting) section.
 
-### Ensuring Installation across Firmware Updates
+### Installation across Firmware Updates
 
 To ensure your installation remains working across firmware updates, you may
 need to perform some manual steps which are described below.
@@ -174,34 +174,37 @@ It is currently not possible to persist the installation across firmware updates
 (see [#120](https://github.com/fabianishere/udm-iptv/issues/120)). Your configuration should remain, so only re-installation is necessary.
 
 ### Configuration
-You can modify the configuration of the service interactively using `dpkg-reconfigure -p medium udm-iptv`.
+You can modify the configuration of the service interactively as follows:
+```bash
+udm-iptv configure
+```
 See below for a reference of the available options to configure:
 
-| Environmental Variable | Description                                                                                             | Default                            |
-|------------------------|---------------------------------------------------------------------------------------------------------|------------------------------------|
-| IPTV_WAN_INTERFACE     | Interface on which IPTV traffic enters the router                                                       | eth8 (on UDM Pro) or eth4 (on UDM) |
-| IPTV_WAN_RANGES        | IP ranges from which the IPTV traffic originates (separated by spaces)                                  | 213.75.0.0/16 217.166.0.0/16       |
-| IPTV_WAN_VLAN          | ID of VLAN which carries IPTV traffic (use 0 if no VLAN is used)                                        | 4                                  |
-| IPTV_WAN_DHCP          | Boolean to indicate whether DHCP is enabled on the IPTV WAN (VLAN) interface                            | true                               |
-| IPTV_WAN_DHCP_OPTIONS  | [DHCP options](https://busybox.net/downloads/BusyBox.html#udhcpc) to send when requesting an IP address | -O staticroutes -V IPTV_RG         |
-| IPTV_WAN_STATIC_IP     | Static IP address to assign to the IPTV WAN (VLAN) interface (if DHCP is disabled)                      |                                    |
-| IPTV_WAN_MAC           | Custom MAC address to assign to the IPTV WAN VLAN interface                                             |                                    |
-| IPTV_LAN_INTERFACES    | Interfaces on which IPTV should be made available                                                       | br0                                |
-| IPTV_IGMPPROXY_DEBUG   | Enable debugging for igmpproxy                                                                          | false                              |
+| Option                | Description                                                                                             |
+|-----------------------|---------------------------------------------------------------------------------------------------------|
+| IPTV_WAN_INTERFACE    | Interface on which IPTV traffic enters the router                                                       |
+| IPTV_WAN_RANGES       | IP ranges from which the IPTV traffic originates (separated by spaces)                                  |
+| IPTV_WAN_VLAN         | ID of VLAN which carries IPTV traffic (use 0 if no VLAN is used)                                        |
+| IPTV_WAN_DHCP         | Boolean to indicate whether DHCP is enabled on the IPTV WAN (VLAN) interface                            |
+| IPTV_WAN_DHCP_OPTIONS | [DHCP options](https://busybox.net/downloads/BusyBox.html#udhcpc) to send when requesting an IP address |
+| IPTV_WAN_STATIC_IP    | Static IP address to assign to the IPTV WAN (VLAN) interface (if DHCP is disabled)                      |
+| IPTV_WAN_MAC          | Custom MAC address to assign to the IPTV WAN VLAN interface                                             |
+| IPTV_LAN_INTERFACES   | Interfaces on which IPTV should be made available                                                       |
+| IPTV_IGMPPROXY_DEBUG  | Enable debugging for igmpproxy                                                                          |
 
 The configuration is written to `/etc/udm-iptv.conf` (within UniFi OS).
 
 ### Upgrading
-To upgrade `udm-iptv`, please re-run the installation script.
+Use the following command to upgrade `udm-iptv`:
+```bash
+udm-iptv upgrade
+```
+If that command does not exist, please re-run the installation script.
 
 ### Removal
 To fully remove an `udm-iptv` installation from your UniFi device, run the follow command:
 ```bash
-apt remove dialog igmpproxy udm-iptv
-```
-In order to remove all configuration files as well, run the following command:
-```bash
-apt purge dialog igmpproxy udm-iptv
+udm-iptv uninstall
 ```
 
 ## Troubleshooting
@@ -227,7 +230,7 @@ only for bugs or feature requests related to the project (no configuration-relat
 When opening a discussion or reporting an issue, **please share the name of your
 ISP as well as the diagnostics reported by our diagnostic tool**:
 ```bash
-udm-iptv-diag
+udm-iptv diagnose
 ```
 
 ## Contributing

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+udm-iptv (3.0.0) stable; urgency=medium
+
+  * Add helper script for managing the udm-iptv installation
+  * Add support for impproxy
+  * Add support for manual static routes
+  * Fix deprecations in GH Actions workflows
+
+ -- Fabian Mastenbroek <mail.fabianm@gmail.com>  Mon, 13 Jan 2022 23:00:00 +0000
+
 udm-iptv (2.1.4) stable; urgency=medium
 
   * Overwrite actual file if config file is symlink

--- a/debian/config
+++ b/debian/config
@@ -97,8 +97,10 @@ if [ -e $CONFIGFILE ]; then
 
     db_set udm-iptv/lan-interfaces "$(echo "$IPTV_LAN_INTERFACES" | tr -s ' ' ',')"
 
+    db_set udm-iptv/igmpproxy-program "$IPTV_IGMPPROXY_PROGRAM"
     db_set udm-iptv/igmpproxy-quickleave "$([ -n "$IPTV_IGMPPROXY_DISABLE_QUICKLEAVE" ] && [ "$IPTV_IGMPPROXY_DISABLE_QUICKLEAVE" != "false" ] && echo "false" || echo "true")"
     db_set udm-iptv/igmpproxy-debug "$IPTV_IGMPPROXY_DEBUG"
+    db_set udm-iptv/igmpproxy-igmp-version "$IPTV_IGMPPROXY_IGMP_VERSION"
 fi
 
 # Facilitate backup capability per debconf-devel(7)
@@ -111,12 +113,12 @@ while true; do
         ;;
     1)  # Configure WAN interface
         case "$board" in
-            UDMPRO|UDMPROSE)
+            UDMPRO|UDMPROSE|UDMSE)
                 db_subst udm-iptv/wan-port choices "WAN 1 (RJ45), WAN 2 (SFP+)"
                 db_subst udm-iptv/wan-port choices_c "eth8, eth9"
                 db_input high udm-iptv/wan-port || true
                 ;;
-            UDM|UDMSE|UDR)
+            UDM|UDR)
                 db_set udm-iptv/wan-port eth4
                 ;;
             *)
@@ -138,13 +140,24 @@ while true; do
         db_subst udm-iptv/lan-interfaces choices_c "$(find /sys/class/net -name "br*" -exec basename {} \; | sort | sed ':a;N;s/\n/, /;ba')"
         db_input high udm-iptv/lan-interfaces || true
         ;;
-    5)  # Configure igmpproxy
-        db_beginblock
-        db_input low udm-iptv/igmpproxy-quickleave || true
-        db_input medium udm-iptv/igmpproxy-debug || true
-        db_endblock
+    5)  # Configure igmpproxy program
+        db_input low udm-iptv/igmpproxy-program || true
         ;;
-    6)  # Complete configuration
+    6)  # Configure igmpproxy
+        db_get udm-iptv/igmpproxy-program
+        if [ "$RET" = "improxy" ]; then
+            db_beginblock
+            db_input medium udm-iptv/igmpproxy-igmp-version || true
+            db_input medium udm-iptv/igmpproxy-debug || true
+            db_endblock
+        else
+            db_beginblock
+            db_input low udm-iptv/igmpproxy-quickleave || true
+            db_input medium udm-iptv/igmpproxy-debug || true
+            db_endblock
+        fi
+        ;;
+    7)  # Complete configuration
         exit 0
         ;;
     *)  # unknown state

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,8 @@ Homepage: https://github.com/fabianishere/udm-iptv
 
 Package: udm-iptv
 Architecture: all
-Depends: busybox | busybox-static, iproute2, iptables, igmpproxy (>= 0.2), ${misc:Depends}
+Depends: busybox | busybox-static, iproute2, iptables, ${misc:Depends}
+Recommend: igmpproxy (>= 0.2)
 Section: net
 Priority: optional
 Description: Helper tool for configuring IPTV on the UniFi Dream Machine (Pro)

--- a/debian/install
+++ b/debian/install
@@ -1,7 +1,8 @@
 README.md usr/share/doc/udm-iptv
 debian/copyright usr/share/doc/udm-iptv
-udm-iptv usr/lib/udm-iptv
+udm-iptvd usr/lib/udm-iptv
 profiles usr/lib/udm-iptv
+udm-iptv usr/bin
 udm-iptv-diag usr/bin
 udhcpc.hook usr/lib/udm-iptv
 udm-iptv.conf etc

--- a/debian/postinst
+++ b/debian/postinst
@@ -79,6 +79,10 @@ fi
 db_get udm-iptv/lan-interfaces
 replace_conf "$tmpconf" "IPTV_LAN_INTERFACES" "$(echo "$RET" | tr ',' ' ')"
 
+
+db_get udm-iptv/igmpproxy-program
+replace_conf "$tmpconf" "IPTV_IGMPPROXY_PROGRAM" "$RET"
+
 db_get udm-iptv/igmpproxy-quickleave
 value="false"
 if [ "$RET" = "false" ]; then
@@ -88,6 +92,9 @@ replace_conf "$tmpconf" "IPTV_IGMPPROXY_DISABLE_QUICKLEAVE" "$value"
 
 db_get udm-iptv/igmpproxy-debug
 replace_conf "$tmpconf" "IPTV_IGMPPROXY_DEBUG" "$RET"
+
+db_get udm-iptv/igmpproxy-igmp-version
+replace_conf "$tmpconf" "IPTV_IGMPPROXY_IGMP_VERSION" "$RET"
 
 # Replace file with updated configuration
 mv "$tmpconf" "$(readlink -f "$CONFIGFILE")"

--- a/debian/templates
+++ b/debian/templates
@@ -65,6 +65,12 @@ Choices: ${choices}
 Choices-C: ${choices_c}
 Default: br0
 
+Template: udm-iptv/igmpproxy-program
+Description: IGMP Proxy implementation:
+Type: select
+Choices: igmpproxy, improxy
+Default: igmpproxy
+
 Template: udm-iptv/igmpproxy-quickleave
 Description: Enable quickleave for igmpproxy?
 Type: boolean
@@ -74,3 +80,10 @@ Template: udm-iptv/igmpproxy-debug
 Description: Enable igmpproxy debugging?
 Type: boolean
 Default: false
+
+Template: udm-iptv/igmpproxy-igmp-version
+Description: IGMP version:
+Type: select
+Choices: IGMPv2, IGMPv3
+Choices-C: 2, 3
+Default: 2

--- a/debian/udm-iptv.service
+++ b/debian/udm-iptv.service
@@ -5,8 +5,8 @@ After=network.target
 [Service]
 Type=simple
 EnvironmentFile=/etc/udm-iptv.conf
-ExecStart=/usr/lib/udm-iptv/udm-iptv start
-ExecStop=/usr/lib/udm-iptv/udm-iptv stop
+ExecStart=/usr/lib/udm-iptv/udm-iptvd start
+ExecStop=/usr/lib/udm-iptv/udm-iptvd stop
 Restart=on-failure
 RestartSec=5s
 

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ if command -v unifi-os > /dev/null 2>&1; then
     exit 1
 fi
 
-UDM_IPTV_VERSION=2.1.4
+UDM_IPTV_VERSION=3.0.0
 IGMPPROXY_VERSION=0.3-1
 
 dest=$(mktemp -d)

--- a/install.sh
+++ b/install.sh
@@ -49,4 +49,4 @@ echo "Installation successful... You can find your configuration at /etc/udm-ipt
 echo
 echo "Use the following command to reconfigure the script:"
 echo
-printf "\t dpkg-reconfigure -p medium udm-iptv\n"
+printf "\t udm-iptv reconfigure\n"

--- a/udm-iptv
+++ b/udm-iptv
@@ -1,173 +1,130 @@
 #!/bin/sh
-# Script for managing the udm-iptv service
+# Script for managing the udm-iptv installation.
 #
-# Copyright (C) 2021 Fabian Mastenbroek.
+# Copyright (C) 2023 Fabian Mastenbroek.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-# Default options
-IPTV_WAN_VLAN_INTERFACE="${IPTV_WAN_VLAN_INTERFACE:-iptv}"
-IPTV_WAN_DHCP_OPTIONS="${IPTV_WAN_DHCP_OPTIONS:-"-O staticroutes -V IPTV_RG"}"
-IPTV_LAN_RANGES="${IPTV_LAN_RANGES:-""}"
+set -eu
 
-# Use busybox if udhcpc is not installed directly
-if ! command -v udhcpc > /dev/null 2>&1; then
-    alias udhcpc="busybox udhcpc"
-fi
-
-# Setup the network, creating the IPTV VLAN interface if necessary
-# and obtaining an IP address for the interface.
-_network_setup() {
-    local target
-    target="$IPTV_WAN_INTERFACE"
-
-    # Make sure we obtain IP address for VLAN interface
-    if [ "$IPTV_WAN_VLAN" -gt 0 ]; then
-        target="$IPTV_WAN_VLAN_INTERFACE"
-
-        if ! ip link show "$IPTV_WAN_INTERFACE" >/dev/null; then
-            echo "Device $IPTV_WAN_INTERFACE for $IPTV_WAN_VLAN_INTERFACE does not exist"
-            exit 1
-        fi
-
-        # Delete existing VLAN interface
-        if [ -e /sys/class/net/"$IPTV_WAN_VLAN_INTERFACE" ]; then
-            echo "Device $IPTV_WAN_VLAN_INTERFACE already exists.. Deleting device"
-            ip link delete dev "$IPTV_WAN_VLAN_INTERFACE"
-        fi
-
-        ip link add link "$IPTV_WAN_INTERFACE" name "$IPTV_WAN_VLAN_INTERFACE" type vlan id "$IPTV_WAN_VLAN"
-
-        # Specify custom MAC address for VLAN interface
-        if [ -n "$IPTV_WAN_VLAN_MAC" ]; then
-            ip link set dev "$IPTV_WAN_VLAN_INTERFACE" address "$IPTV_WAN_VLAN_MAC"
-        fi
-
-        # Bring VLAN interface up
-        ip link set dev "$IPTV_WAN_VLAN_INTERFACE" up
-
-        if [ "$IPTV_WAN_DHCP" != "false" ]; then
-            echo "Obtaining IP address for VLAN interface"
-
-            # Obtain IP address for VLAN interface
-            udhcpc -b -R -p /var/run/udhcpc."$IPTV_WAN_VLAN_INTERFACE".pid -s "$(dirname "$0")"/udhcpc.hook -i "$IPTV_WAN_VLAN_INTERFACE" $IPTV_WAN_DHCP_OPTIONS
-        fi
-    fi
-
-    if [ "$IPTV_WAN_DHCP" = "false" ] && [ -n "$IPTV_WAN_STATIC_IP" ]; then
-        ip -4 addr change "$IPTV_WAN_STATIC_IP" dev "$target"
-    fi
-
-    echo "NATing IPTV network ranges (if necessary)"
-
-    # NAT the IPTV ranges
-    for range in $IPTV_WAN_RANGES; do
-        # Only add the NAT rule if it does not yet exist
-        if ! iptables -C POSTROUTING -t nat -d "$range" -j MASQUERADE -o "$target" >/dev/null 2>&1; then
-            iptables -A POSTROUTING -t nat -d "$range" -j MASQUERADE -o "$target"
-        fi
-    done
+# (Re)configure the udm-iptv installation
+udm_iptv_configure()
+{
+    dpkg-reconfigure -p low udm-iptv
 }
 
-# Watch for network changes and re-apply the configuration
-_network_watch() {
-    if [ "$IPTV_WAN_VLAN" -gt 0 ]; then
-        return
-    fi
-
-    echo "Monitoring interface $IPTV_WAN_INTERFACE for changes"
-
-    # Monitor for changes on the WAN interface
-    ip monitor address dev "$IPTV_WAN_INTERFACE" | while read line; do
-        if echo "$line" | grep -q "Deleted"; then
-            _network_setup
-        fi
-    done & # Monitoring happens in background
+# Upgrade udm-iptv installation to latest version
+udm_iptv_upgrade()
+{
+    echo "Running udm-iptv installer..."
+    sh -c "$(curl https://raw.githubusercontent.com/fabianishere/udm-iptv/master/install.sh -sSf)"
 }
 
-# Tear down the network configuration
-_network_teardown() {
-    # Delete the IPTables rules
-    for range in $IPTV_WAN_RANGES; do
-        iptables -D POSTROUTING -t nat -d "$range" -j MASQUERADE -o "$target" >/dev/null 2>&1
-    done
+# Remove the udm-iptv installation from the system
+udm_iptv_uninstall()
+{
+    apt-get remove -y dialog igmpproxy udm-iptv
 }
 
-# Build the configuration needed by IGMP Proxy
-_igmpproxy_build_config() {
-    echo "# igmpproxy configuration for udm-iptv"
-    if [ -z "$IPTV_IGMPPROXY_DISABLE_QUICKLEAVE" ] || [ "$IPTV_IGMPPROXY_DISABLE_QUICKLEAVE" = "false" ]; then
-        echo "quickleave"
+# Restart the udm-iptv daemon via systemd
+udm_iptv_restart()
+{
+    systemctl restart udm-iptv
+}
+
+# Print diagnostics for troubleshooting
+udm_iptv_diagnose()
+{
+    if ! [ -e /etc/udm-iptv.conf ] ; then
+        echo "error: The configuration for udm-iptv is not found."
+        echo "Please reconfigure your udm-iptv installation:"
+        echo "    udm-iptv reconfigure"
+        exit 1
     fi
 
-    local target
-    if [ "$IPTV_WAN_VLAN" -gt 0 ]; then
+    # Load configuration
+    . /etc/udm-iptv.conf
+
+    if [ "$IPTV_WAN_VLAN" -ne 0 ]; then
         target="$IPTV_WAN_VLAN_INTERFACE"
     else
         target="$IPTV_WAN_INTERFACE"
     fi
 
-    echo "phyint $target upstream  ratelimit 0  threshold 1"
-    for range in $IPTV_LAN_RANGES $IPTV_WAN_RANGES; do
-        echo "  altnet $range"
-    done
-
-    # Configure the igmpproxy interfaces
-    for path in /sys/class/net/*; do
-        local interface
-        interface=$(basename "$path")
-        if echo "$IPTV_LAN_INTERFACES" | grep -w -q "$interface"; then
-            echo "phyint $interface downstream  ratelimit 0  threshold 1"
-        elif [ "$interface" != "lo" ] && [ "$interface" != "$target" ]; then
-            echo "phyint $interface disabled"
-        fi
-    done
-}
-
-# Configure IGMP Proxy to bridge multicast traffic
-_igmpproxy_setup() {
-    echo "Setting up igmpproxy"
-    _igmpproxy_build_config >/var/run/igmpproxy.iptv.conf
-}
-
-# Tear down the IGMP Proxy configuration
-_igmpproxy_teardown() {
-    rm -f /var/run/igmpproxy.iptv.conf
-}
-
-# Start the igmpproxy service
-_igmpproxy_start() {
-    echo "Starting igmpproxy"
-    args=""
-    if [ -n "$IPTV_IGMPPROXY_DEBUG" ] && [ "$IPTV_IGMPPROXY_DEBUG" != "false" ]; then
-        args="-d -v"
+    echo "Please share the following output with the developers:"
+    echo "=== Configuration ==="
+    echo "WAN Interface: $IPTV_WAN_INTERFACE"
+    echo "WAN VLAN: $IPTV_WAN_VLAN (dev $IPTV_WAN_VLAN_INTERFACE$([ -n "${IPTV_WAN_VLAN_MAC:-}" ] && echo " mac $IPTV_WAN_VLAN_MAC"))"
+    echo "WAN DHCP: $([ -n "${IPTV_WAN_DHCP:-}" ] && echo "$IPTV_WAN_DHCP" || echo "true") (options \"$IPTV_WAN_DHCP_OPTIONS\")"
+    if [ -n "${IPTV_WAN_STATIC_IP:-}" ]; then
+        echo "WAN Static IP: $IPTV_WAN_STATIC_IP"
     fi
-    # shellcheck disable=SC2086
-    exec igmpproxy -n $args "$@" /var/run/igmpproxy.iptv.conf
+    echo "WAN Ranges: $IPTV_WAN_RANGES"
+    echo "LAN Interfaces: $IPTV_LAN_INTERFACES"
+    echo "IGMP Proxy quickleave disabled: $IPTV_IGMPPROXY_DISABLE_QUICKLEAVE"
+    echo "IGMP Proxy debug: $IPTV_IGMPPROXY_DEBUG"
+
+    echo "=== IP Link and Route ==="
+    ip -4 addr show dev "$target" || true
+    ip route show dev "$target" || true
+
+    echo "=== Service Logs ==="
+    journalctl -u udm-iptv | tail
+}
+
+# Print the help message of this program.
+udm_iptv_usage()
+{
+	cat << EOF
+Usage: $0 [OPTIONS...] COMMAND [ARGS]...
+Helper tool for routed IPTV on the UniFi Dream Machine (Pro/SE).
+Commands:
+  configure         Re-configure the udm-iptv installation
+  upgrade           Upgrade the udm-iptv installation to the latest version
+  uninstall         Remove udm-iptv from the system
+  restart           Restart the udm-iptv daemon
+  diagnose          Diagnose issues with the current configuration
+Options:
+  -h, --help    Show this message and exit
+EOF
 }
 
 # Check if the user passed any argument
 if [ $# -eq 0 ]; then
+    udm_iptv_usage
     exit 1
 fi
 
 case $1 in
-    start)
-        shift
-        _network_setup
-        _network_watch
-        _igmpproxy_setup
-        _igmpproxy_start "$@"
+    -h|--help)
+        udm_iptv_usage
+        exit 0
         ;;
-    stop)
+    configure|reconfigure)
         shift
-        _network_teardown
-        _igmpproxy_teardown
+        udm_iptv_configure "$@"
+        ;;
+    upgrade)
+        shift
+        udm_iptv_upgrade "$@"
+        ;;
+    uninstall)
+        shift
+        udm_iptv_uninstall "$@"
+        ;;
+    restart)
+        shift
+        udm_iptv_restart "$@"
+        ;;
+    diag|diagnose)
+        shift
+        udm_iptv_diagnose "$@"
         ;;
     *)
+        udm_iptv_usage
         exit 1
         ;;
 esac

--- a/udm-iptv-diag
+++ b/udm-iptv-diag
@@ -8,31 +8,4 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-# Load configuration
-. /etc/udm-iptv.conf
-
-if [ "$IPTV_WAN_VLAN" -ne 0 ]; then
-    target="$IPTV_WAN_VLAN_INTERFACE"
-else
-    target="$IPTV_WAN_INTERFACE"
-fi
-
-echo "Please share the following output with the developers:"
-echo "=== Configuration ==="
-echo "WAN Interface: $IPTV_WAN_INTERFACE"
-echo "WAN VLAN: $IPTV_WAN_VLAN (dev $IPTV_WAN_VLAN_INTERFACE$([ -n "$IPTV_WAN_VLAN_MAC" ] && echo " mac $IPTV_WAN_VLAN_MAC"))"
-echo "WAN DHCP: $([ -n "$IPTV_WAN_DHCP" ] && echo "$IPTV_WAN_DHCP" || echo "true") (options \"$IPTV_WAN_DHCP_OPTIONS\")"
-if [ -n "$IPTV_WAN_STATIC_IP" ]; then
-    echo "WAN Static IP: $IPTV_WAN_STATIC_IP"
-fi
-echo "WAN Ranges: $IPTV_WAN_RANGES"
-echo "LAN Interfaces: $IPTV_LAN_INTERFACES"
-echo "IGMP Proxy quickleave disabled: $IPTV_IGMPPROXY_DISABLE_QUICKLEAVE"
-echo "IGMP Proxy debug: $IPTV_IGMPPROXY_DEBUG"
-
-echo "=== IP Link and Route ==="
-ip -4 addr show dev "$target"
-ip route show dev "$target"
-
-echo "=== Service Logs ==="
-journalctl -u udm-iptv | tail
+exec udm-iptv diagnose

--- a/udm-iptvd
+++ b/udm-iptvd
@@ -1,0 +1,173 @@
+#!/bin/sh
+# Script for managing the udm-iptv service
+#
+# Copyright (C) 2021 Fabian Mastenbroek.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# Default options
+IPTV_WAN_VLAN_INTERFACE="${IPTV_WAN_VLAN_INTERFACE:-iptv}"
+IPTV_WAN_DHCP_OPTIONS="${IPTV_WAN_DHCP_OPTIONS:-"-O staticroutes -V IPTV_RG"}"
+IPTV_LAN_RANGES="${IPTV_LAN_RANGES:-""}"
+
+# Use busybox if udhcpc is not installed directly
+if ! command -v udhcpc > /dev/null 2>&1; then
+    alias udhcpc="busybox udhcpc"
+fi
+
+# Setup the network, creating the IPTV VLAN interface if necessary
+# and obtaining an IP address for the interface.
+_network_setup() {
+    local target
+    target="$IPTV_WAN_INTERFACE"
+
+    # Make sure we obtain IP address for VLAN interface
+    if [ "$IPTV_WAN_VLAN" -gt 0 ]; then
+        target="$IPTV_WAN_VLAN_INTERFACE"
+
+        if ! ip link show "$IPTV_WAN_INTERFACE" >/dev/null; then
+            echo "Device $IPTV_WAN_INTERFACE for $IPTV_WAN_VLAN_INTERFACE does not exist"
+            exit 1
+        fi
+
+        # Delete existing VLAN interface
+        if [ -e /sys/class/net/"$IPTV_WAN_VLAN_INTERFACE" ]; then
+            echo "Device $IPTV_WAN_VLAN_INTERFACE already exists.. Deleting device"
+            ip link delete dev "$IPTV_WAN_VLAN_INTERFACE"
+        fi
+
+        ip link add link "$IPTV_WAN_INTERFACE" name "$IPTV_WAN_VLAN_INTERFACE" type vlan id "$IPTV_WAN_VLAN"
+
+        # Specify custom MAC address for VLAN interface
+        if [ -n "$IPTV_WAN_VLAN_MAC" ]; then
+            ip link set dev "$IPTV_WAN_VLAN_INTERFACE" address "$IPTV_WAN_VLAN_MAC"
+        fi
+
+        # Bring VLAN interface up
+        ip link set dev "$IPTV_WAN_VLAN_INTERFACE" up
+
+        if [ "$IPTV_WAN_DHCP" != "false" ]; then
+            echo "Obtaining IP address for VLAN interface"
+
+            # Obtain IP address for VLAN interface
+            udhcpc -b -R -p /var/run/udhcpc."$IPTV_WAN_VLAN_INTERFACE".pid -s "$(dirname "$0")"/udhcpc.hook -i "$IPTV_WAN_VLAN_INTERFACE" $IPTV_WAN_DHCP_OPTIONS
+        fi
+    fi
+
+    if [ "$IPTV_WAN_DHCP" = "false" ] && [ -n "$IPTV_WAN_STATIC_IP" ]; then
+        ip -4 addr change "$IPTV_WAN_STATIC_IP" dev "$target"
+    fi
+
+    echo "NATing IPTV network ranges (if necessary)"
+
+    # NAT the IPTV ranges
+    for range in $IPTV_WAN_RANGES; do
+        # Only add the NAT rule if it does not yet exist
+        if ! iptables -C POSTROUTING -t nat -d "$range" -j MASQUERADE -o "$target" >/dev/null 2>&1; then
+            iptables -A POSTROUTING -t nat -d "$range" -j MASQUERADE -o "$target"
+        fi
+    done
+}
+
+# Watch for network changes and re-apply the configuration
+_network_watch() {
+    if [ "$IPTV_WAN_VLAN" -gt 0 ]; then
+        return
+    fi
+
+    echo "Monitoring interface $IPTV_WAN_INTERFACE for changes"
+
+    # Monitor for changes on the WAN interface
+    ip monitor address dev "$IPTV_WAN_INTERFACE" | while read line; do
+        if echo "$line" | grep -q "Deleted"; then
+            _network_setup
+        fi
+    done & # Monitoring happens in background
+}
+
+# Tear down the network configuration
+_network_teardown() {
+    # Delete the IPTables rules
+    for range in $IPTV_WAN_RANGES; do
+        iptables -D POSTROUTING -t nat -d "$range" -j MASQUERADE -o "$target" >/dev/null 2>&1
+    done
+}
+
+# Build the configuration needed by IGMP Proxy
+_igmpproxy_build_config() {
+    echo "# igmpproxy configuration for udm-iptv"
+    if [ -z "$IPTV_IGMPPROXY_DISABLE_QUICKLEAVE" ] || [ "$IPTV_IGMPPROXY_DISABLE_QUICKLEAVE" = "false" ]; then
+        echo "quickleave"
+    fi
+
+    local target
+    if [ "$IPTV_WAN_VLAN" -gt 0 ]; then
+        target="$IPTV_WAN_VLAN_INTERFACE"
+    else
+        target="$IPTV_WAN_INTERFACE"
+    fi
+
+    echo "phyint $target upstream  ratelimit 0  threshold 1"
+    for range in $IPTV_LAN_RANGES $IPTV_WAN_RANGES; do
+        echo "  altnet $range"
+    done
+
+    # Configure the igmpproxy interfaces
+    for path in /sys/class/net/*; do
+        local interface
+        interface=$(basename "$path")
+        if echo "$IPTV_LAN_INTERFACES" | grep -w -q "$interface"; then
+            echo "phyint $interface downstream  ratelimit 0  threshold 1"
+        elif [ "$interface" != "lo" ] && [ "$interface" != "$target" ]; then
+            echo "phyint $interface disabled"
+        fi
+    done
+}
+
+# Configure IGMP Proxy to bridge multicast traffic
+_igmpproxy_setup() {
+    echo "Setting up igmpproxy"
+    _igmpproxy_build_config >/var/run/igmpproxy.iptv.conf
+}
+
+# Tear down the IGMP Proxy configuration
+_igmpproxy_teardown() {
+    rm -f /var/run/igmpproxy.iptv.conf
+}
+
+# Start the igmpproxy service
+_igmpproxy_start() {
+    echo "Starting igmpproxy"
+    args=""
+    if [ -n "$IPTV_IGMPPROXY_DEBUG" ] && [ "$IPTV_IGMPPROXY_DEBUG" != "false" ]; then
+        args="-d -v"
+    fi
+    # shellcheck disable=SC2086
+    exec igmpproxy -n $args "$@" /var/run/igmpproxy.iptv.conf
+}
+
+# Check if the user passed any argument
+if [ $# -eq 0 ]; then
+    exit 1
+fi
+
+case $1 in
+    start)
+        shift
+        _network_setup
+        _network_watch
+        _igmpproxy_setup
+        _igmpproxy_start "$@"
+        ;;
+    stop)
+        shift
+        _network_teardown
+        _igmpproxy_teardown
+        ;;
+    *)
+        exit 1
+        ;;
+esac

--- a/udm-iptvd
+++ b/udm-iptvd
@@ -127,10 +127,47 @@ _igmpproxy_build_config() {
     done
 }
 
+# Build the configuration needed by IMProxy
+_igmpproxy_build_config_improxy() {
+    echo "# improxy configuration for udm-iptv"
+    if [ "$IPTV_IGMPPROXY_IGMP_VERSION" = 3 ]; then
+        echo "igmp enable version 3"
+    else
+        echo "igmp enable version 2"
+    fi
+
+    echo "mld disable"
+
+    local target
+    if [ "$IPTV_WAN_VLAN" -gt 0 ]; then
+        target="$IPTV_WAN_VLAN_INTERFACE"
+    else
+        target="$IPTV_WAN_INTERFACE"
+    fi
+
+    echo "upstream $target"
+
+    # Configure the upstream interfaces
+    for path in /sys/class/net/*; do
+        local interface
+        interface=$(basename "$path")
+        if echo "$IPTV_LAN_INTERFACES" | grep -w -q "$interface"; then
+            echo "downstream $interface"
+        fi
+    done
+}
+
 # Configure IGMP Proxy to bridge multicast traffic
 _igmpproxy_setup() {
-    echo "Setting up igmpproxy"
-    _igmpproxy_build_config >/var/run/igmpproxy.iptv.conf
+    echo "Setting up IGMP Proxy"
+
+    if [ "$IPTV_IGMPPROXY_PROGRAM" = "improxy" ]; then
+        echo "Using improxy..."
+        _igmpproxy_build_config_improxy > /var/run/igmpproxy.iptv.conf
+    else
+        echo "Using igmpproxy..."
+        _igmpproxy_build_config > /var/run/igmpproxy.iptv.conf
+    fi
 }
 
 # Tear down the IGMP Proxy configuration
@@ -140,14 +177,35 @@ _igmpproxy_teardown() {
 
 # Start the igmpproxy service
 _igmpproxy_start() {
-    echo "Starting igmpproxy"
+    echo "Starting IGMP Proxy"
     args=""
     if [ -n "$IPTV_IGMPPROXY_DEBUG" ] && [ "$IPTV_IGMPPROXY_DEBUG" != "false" ]; then
-        args="-d -v"
+        if [ "$IPTV_IGMPPROXY_PROGRAM" = "improxy" ]; then
+            args="-d -5"
+        else
+            args="-d -v"
+        fi
     fi
-    # shellcheck disable=SC2086
-    exec igmpproxy -n $args "$@" /var/run/igmpproxy.iptv.conf
+
+    if [ "$IPTV_IGMPPROXY_PROGRAM" = "improxy" ]; then
+        if ! command -v improxy > /dev/null 2>&1; then
+            echo "error: improxy not installed..."
+            exit 1
+        fi
+
+        # shellcheck disable=SC2086
+        exec improxy $args "$@" -c /var/run/igmpproxy.iptv.conf
+    else
+        if ! command -v igmpproxy > /dev/null 2>&1; then
+            echo "error: igmpproxy not installed..."
+            exit 1
+        fi
+
+        # shellcheck disable=SC2086
+        exec igmpproxy -n $args "$@" /var/run/igmpproxy.iptv.conf
+    fi
 }
+
 
 # Check if the user passed any argument
 if [ $# -eq 0 ]; then

--- a/udm-iptvd
+++ b/udm-iptvd
@@ -70,6 +70,11 @@ _network_setup() {
             iptables -A POSTROUTING -t nat -d "$range" -j MASQUERADE -o "$target"
         fi
     done
+
+    echo "Creating static routes (if necessary)"
+    for range in $IPTV_STATIC_ROUTES; do
+        ip route add "$range" dev "$target"
+    done
 }
 
 # Watch for network changes and re-apply the configuration


### PR DESCRIPTION
This pull request adds experimental support for using improxy (included in UbiOS) as IGMP Proxy.

Furthermore, we also introduce a new helper script `udm-iptv` to simplify the management of the `udm-iptv` application.