### PR TITLE
Add Vodafone PT Profile

### DIFF
--- a/debian/config
+++ b/debian/config
@@ -60,6 +60,7 @@ _list_profiles() {
     echo "telenor", "Telenor (NO)"
     echo "vivo", "Vivo SP (BR)"
     echo "posttv", "PostTV (LU)"
+    echo "vodafone-pt", "Vodafone (PT)"
 }
 
 # Obtain the board name of the device running the installation script

--- a/profiles/vodafone-pt.profile
+++ b/profiles/vodafone-pt.profile
@@ -1,0 +1,16 @@
+#!/bin/sh -e
+# Profile for Vodafone (PT)
+#
+# Copyright (C) 2023 Fabian Mastenbroek.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+db_get udm-iptv/wan-port
+db_set udm-iptv/wan-interface "$RET"
+
+db_set udm-iptv/wan-vlan 0
+db_set udm-iptv/wan-ranges "0.0.0.0/0"
+db_set udm-iptv/wan-dhcp false


### PR DESCRIPTION
/etc/udm-iptv.conf configuration for Vodafone PT.
@fabianishere I don't know how to make this file look like a profile like the others, just wanted to contribute with my working configuration after many sleepless hours making this work. This is working with the IPTV box behind 3 routers. IPS Router > UDR > Asus with Tomato > iptv box. If my setup works, simpler setups should work flawlessly.