### PR TITLE
Use improxy as default IGMP Proxy program

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+udm-iptv (3.0.3) stable; urgency=medium
+
+  * Change default from igmpproxy to impproxy
+
+ -- Fabian Mastenbroek <mail.fabianm@gmail.com>  Tue, 27 Jun 2023 20:00:00 +0000
+
 udm-iptv (3.0.2) stable; urgency=medium
 
   * Add support for UGX Pro (firmware 3.0.x)

--- a/debian/config
+++ b/debian/config
@@ -147,6 +147,15 @@ while true; do
         db_input high udm-iptv/lan-interfaces || true
         ;;
     5)  # Configure igmpproxy program
+        programs=""
+        if command -v improxy > /dev/null 2>&1; then
+            programs="improxy"
+        fi
+        if command -v igmpproxy > /dev/null 2>&1; then
+            programs="$programs igmpproxy"
+        fi
+
+        db_subst udm-iptv/igmpproxy-program choices "$(echo $programs | sed 's/ /, /g')"
         db_input low udm-iptv/igmpproxy-program || true
         ;;
     6)  # Configure igmpproxy

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,8 @@ Homepage: https://github.com/fabianishere/udm-iptv
 Package: udm-iptv
 Architecture: all
 Depends: busybox | busybox-static, iproute2, iptables, ${misc:Depends}
-Recommends: igmpproxy (>= 0.2)
+Recommends: improxy
+Suggests: igmpproxy (>= 0.2)
 Section: net
 Priority: optional
 Description: Helper tool for configuring IPTV on the UniFi Dream Machine (Pro)

--- a/debian/templates
+++ b/debian/templates
@@ -68,9 +68,8 @@ Default: br0
 Template: udm-iptv/igmpproxy-program
 _Description: IGMP Proxy implementation:
 Type: select
-Choices: igmpproxy (Default), improxy
-Choices-C: igmpproxy, improxy
-Default: igmpproxy
+Choices: ${choices}
+Default: improxy
 
 Template: udm-iptv/igmpproxy-quickleave
 _Description: Enable quickleave for igmpproxy?

--- a/debian/udm-iptv.service
+++ b/debian/udm-iptv.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=IPTV support for the UniFi Dream Machine
 After=network.target
+Conflicts=igmpproxy.service
 
 [Service]
 Type=simple

--- a/install.sh
+++ b/install.sh
@@ -18,8 +18,7 @@ if command -v unifi-os > /dev/null 2>&1; then
     exit 1
 fi
 
-UDM_IPTV_VERSION=3.0.2
-IGMPPROXY_VERSION=0.3-1
+UDM_IPTV_VERSION=3.0.3
 
 dest=$(mktemp -d)
 
@@ -28,22 +27,19 @@ echo "Downloading packages..."
 # Download udm-iptv package
 curl -sS -o "$dest/udm-iptv.deb" -L "https://github.com/fabianishere/udm-iptv/releases/download/v$UDM_IPTV_VERSION/udm-iptv_${UDM_IPTV_VERSION}_all.deb"
 
-# Download a recent igmpproxy version
-curl -sS -o "$dest/igmpproxy.deb" -L "http://ftp.debian.org/debian/pool/main/i/igmpproxy/igmpproxy_${IGMPPROXY_VERSION}_arm64.deb"
-
 # Fix permissions on the packages
-chown _apt:root "$dest/udm-iptv.deb" "$dest/igmpproxy.deb"
+chown _apt:root "$dest/udm-iptv.deb"
 
 echo "Installing packages..."
 
 # Update APT sources (best effort)
-apt-get update -q || true
+apt-get update -q 2>&1 /dev/null || true
 
 # Install dialog package for interactive install
-apt-get install -q -y dialog || echo "Failed to install dialog... Using readline frontend"
+apt-get install -q -y dialog 2>&1 /dev/null || echo "Failed to install dialog... Using readline frontend"
 
-# Install udm-iptv and igmpproxy
-apt-get install -q -y "$dest/igmpproxy.deb" "$dest/udm-iptv.deb"
+# Install udm-iptv
+apt-get install -q "$dest/udm-iptv.deb"
 
 # Delete downloaded packages
 rm -rf "$dest"


### PR DESCRIPTION
This change updates the default IGMP Proxy program to be improxy. It comes pre-installed on the UniFi Dream Machine and has proven to be more stable than igmpproxy.