### PR TITLE
Add support for UXG Lite LAN interfaces

### DIFF
--- a/debian/config
+++ b/debian/config
@@ -27,6 +27,17 @@ _if_inet_list() {
     done
 }
 
+_if_inet_list_uxg() {
+    for interface in $(find /sys/class/net \( -name "br*" -o -name "eth0*" \) -a ! -name "eth0" -exec basename {} \; | sort); do
+        id=$(echo "$interface" | sed -n 's/\(br\|eth\)\(\d*\)/\2/p')
+        type="LAN"
+        if [ "$id" -gt 0 ]; then
+            type="VLAN $id"
+        fi
+        printf "%-9s [IPv4: %s]\n" "$type" "$(_if_inet_addr "$interface")"
+    done
+}
+
 # Helper function to list the lower interface of some interface
 _if_inet_list_lower() {
     for path in "$1"/lower_*; do
@@ -145,8 +156,16 @@ while true; do
         . /usr/lib/udm-iptv/profiles/"$RET".profile
         ;;
     4)  # Select LAN interfaces
-        db_subst udm-iptv/lan-interfaces choices "$(_if_inet_list | sed ':a;N;s/\n/, /;ba')"
-        db_subst udm-iptv/lan-interfaces choices_c "$(find /sys/class/net -name "br*" -exec basename {} \; | sort | sed ':a;N;s/\n/, /;ba')"
+        case "$board" in
+            UXG)
+                db_subst udm-iptv/lan-interfaces choices "$(_if_inet_list_uxg | sed ':a;N;s/\n/, /;ba')"
+                db_subst udm-iptv/lan-interfaces choices_c "$(find /sys/class/net \( -name "br*" -o -name "eth0*" \) -a ! -name eth0 -exec basename {} \; | sort | sed ':a;N;s/\n/, /;ba')"
+                ;;
+            *)
+                db_subst udm-iptv/lan-interfaces choices "$(_if_inet_list | sed ':a;N;s/\n/, /;ba')"
+                db_subst udm-iptv/lan-interfaces choices_c "$(find /sys/class/net -name "br*" -exec basename {} \; | sort | sed ':a;N;s/\n/, /;ba')"
+                ;;
+        esac
         db_input high udm-iptv/lan-interfaces || true
         ;;
     5)  # Configure igmpproxy program


### PR DESCRIPTION
This PR will add support for selecting the LAN interfaces on UXG Lite in `udm-iptv reconfigure`:
* UXG Lite uses br0 for the primary LAN interface (default 192.168.1.1), but eth0.* for the VLANs
* eth0 is also defined but has no IP configuration, so filter that one out

`ip a | grep -B 2 'inet '` (I use VLAN 1 /3 5 / 7 / 179):
```
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1
    link/loopback f6:e2:c6:da:e8:19 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
--
13: br0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether f4:e2:c6:da:e8:19 brd ff:ff:ff:ff:ff:ff
    inet 192.168.1.1/24 scope global br0
--
14: eth0.179@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether f4:e2:c6:da:e8:19 brd ff:ff:ff:ff:ff:ff
    inet 192.168.179.1/24 scope global eth0.179
--
15: eth0.3@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether f4:e2:c6:da:e8:19 brd ff:ff:ff:ff:ff:ff
    inet 192.168.3.1/24 scope global eth0.3
--
16: eth0.5@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether f4:e2:c6:da:e8:19 brd ff:ff:ff:ff:ff:ff
    inet 192.168.5.1/24 scope global eth0.5
--
17: eth0.7@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether f4:e2:c6:da:e8:19 brd ff:ff:ff:ff:ff:ff
    inet 192.168.7.1/24 scope global eth0.7
```
