### PR TITLE
Add UCG Ultra support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+udm-iptv (3.0.5) stable; urgency=medium
+
+  * Support for UCG Ultra in configuration
+
+ -- Erik Post <erik.post@eml.cc>  Sun, 28 Apr 2024 12:00:00 +0000
+
 udm-iptv (3.0.4) stable; urgency=medium
 
   * Support UXG Lite in configuration

--- a/debian/config
+++ b/debian/config
@@ -131,8 +131,8 @@ while true; do
                 db_input high udm-iptv/wan-port || true
                 ;;
             UXGPRO)
-                db_subst udm-iptv/wan-port choices "WAN (2.5 GbE), LAN 4 (1 GbE)"
-                db_subst udm-iptv/wan-port choices_c "eth4, eth3"
+                db_subst udm-iptv/wan-port choices "WAN 1 (RJ45), WAN 2 (SFP+)"
+                db_subst udm-iptv/wan-port choices_c "eth0, eth2"
                 db_input high udm-iptv/wan-port || true
                 ;;
             UDM|UDR)
@@ -142,8 +142,8 @@ while true; do
                 db_set udm-iptv/wan-port eth1
                 ;;
             UDRULT)
-                db_subst udm-iptv/wan-port choices "WAN 1 (RJ45), WAN 2 (SFP+)"
-                db_subst udm-iptv/wan-port choices_c "eth8, eth9"
+                db_subst udm-iptv/wan-port choices "WAN (2.5 GbE), LAN 4 (1 GbE)"
+                db_subst udm-iptv/wan-port choices_c "eth4, eth3"
                 db_input high udm-iptv/wan-port || true
                 ;;
             *)

--- a/debian/config
+++ b/debian/config
@@ -131,8 +131,8 @@ while true; do
                 db_input high udm-iptv/wan-port || true
                 ;;
             UXGPRO)
-                db_subst udm-iptv/wan-port choices "WAN 1 (RJ45), WAN 2 (SFP+)"
-                db_subst udm-iptv/wan-port choices_c "eth0, eth2"
+                db_subst udm-iptv/wan-port choices "WAN (2.5 GbE), LAN 4 (1 GbE)"
+                db_subst udm-iptv/wan-port choices_c "eth4, eth3"
                 db_input high udm-iptv/wan-port || true
                 ;;
             UDM|UDR)
@@ -140,6 +140,11 @@ while true; do
                 ;;
             UXG)
                 db_set udm-iptv/wan-port eth1
+                ;;
+            UDRULT)
+                db_subst udm-iptv/wan-port choices "WAN 1 (RJ45), WAN 2 (SFP+)"
+                db_subst udm-iptv/wan-port choices_c "eth8, eth9"
+                db_input high udm-iptv/wan-port || true
                 ;;
             *)
                 db_set udm-iptv/wan-port eth8

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ if command -v unifi-os > /dev/null 2>&1; then
     exit 1
 fi
 
-UDM_IPTV_VERSION=3.0.4
+UDM_IPTV_VERSION=3.0.5
 
 dest=$(mktemp -d)
 


### PR DESCRIPTION
Hi, I have added support for the UCG Ultra, which seems to be a popular device for people replacing an USG or starting with Unifi. The change adds the selection of the correct WAN port in the configuration wizard. Based on discussions on Tweakers forums the interface names for the VLAN work the same as other Unifi consoles, so I didn't change anything there.

Unfortunately I don't have a UCG Ultra to test this out for myself, but I did emulate it a bit by manually creating an /etc/board.info file for the UCG Ultra, and verifying data and network interface names with a UCG Ultra owner.