### PR TITLE
Update init7.profile

### DIFF
--- a/profiles/init7.profile
+++ b/profiles/init7.profile
@@ -12,5 +12,5 @@ db_get udm-iptv/wan-port
 db_set udm-iptv/wan-interface "$RET"
 
 db_set udm-iptv/wan-vlan 0
-db_set udm-iptv/wan-ranges "224.0.0.0/8, 239.0.0.0/8, 77.109.128.0/19"
+db_set udm-iptv/wan-ranges "224.0.0.0/8, 239.77.0.0/16, 77.109.128.0/19, 233.50.230.0/24"
 db_set udm-iptv/wan-dhcp false


### PR DESCRIPTION
Init7 are updating their IPTV infrastructure[1].

The new playlists[2] already point to a new mcast subnet (233.50.230.0/24), and the legacy one (239.77.0.0/16) will be deprecated in the next months.

Tested working on my build (both with udm-iptv as well as native igmpproxy on UDMP).

Sources:
[1] https://www.init7.net/en/support/faq/mit-welchen-uebertragungsarten-funktionieren-die-tv-streams/ (turn on nerdmode from bottom left)
[2] direct link to the updated playlist, showing new mutlcast address: https://api.init7.net/tvchannels.xspf