### PR TITLE
feat: add support for Unifi Cloud Gateway Max

### DIFF
--- a/debian/config
+++ b/debian/config
@@ -146,6 +146,11 @@ while true; do
                 db_subst udm-iptv/wan-port choices_c "eth4, eth3"
                 db_input high udm-iptv/wan-port || true
                 ;;
+            UCGMAX)
+                db_subst udm-iptv/wan-port choices "WAN, LAN 4"
+                db_subst udm-iptv/wan-port choices_c "eth4, eth3"
+                db_input high udm-iptv/wan-port || true
+                ;;
             *)
                 db_set udm-iptv/wan-port eth8
                 ;;


### PR DESCRIPTION
Add support for selecting WAN port of Unifi Cloud Gateway Max. Based on board short name from #338 and fact that UCG Max has same number of ports and interfaces names as UCG Ultra. Untested by myself because I do not have a UCG Max.