### PR TITLE
Update kpn.profile

### DIFF
--- a/profiles/kpn.profile
+++ b/profiles/kpn.profile
@@ -12,5 +12,5 @@ db_get udm-iptv/wan-port
 db_set udm-iptv/wan-interface "$RET"
 
 db_set udm-iptv/wan-vlan 4
-db_set udm-iptv/wan-ranges "213.75.0.0/16, 217.166.0.0/16"
+db_set udm-iptv/wan-ranges "213.75.0.0/16, 217.166.0.0/16, 195.121.0.0/16"
 db_set udm-iptv/wan-dhcp-options "-O staticroutes -V IPTV_RG"


### PR DESCRIPTION
I had some errors in the igmpproxy logs:
Feb 08 13:40:57 UXG-Pro udm-iptvd[2307]: The source address 195.121.94.212 for group 224.0.250.64, is not in any valid net for upstream VIF[0].

Looking for this online, it seems that KPN changed or added something. See:
https://community.kpn.com/kpn-tv-11/ontvangers-blijven-hangen-op-80-na-update-modem-626696

Adding to the NAT rules 195.121.0.0/16 showed no more of these messages in the logs.