### PR TITLE
UniFi Dream Router 7 and Freedom Internet profile

### DIFF
--- a/debian/config
+++ b/debian/config
@@ -138,6 +138,10 @@ while true; do
             UDM|UDR)
                 db_set udm-iptv/wan-port eth4
                 ;;
+            UDR7)
+                db_subst udm-iptv/wan-port choices "LAN 3 (RJ45), WAN 1 (RJ45), WAN 2 (SFP+)"
+                db_subst udm-iptv/wan-port choices_c "eth2, eth3, eth4"
+                db_input high udm-iptv/wan-port || true
             UXG)
                 db_set udm-iptv/wan-port eth1
                 ;;

--- a/debian/config
+++ b/debian/config
@@ -62,6 +62,7 @@ _if_inet_list_upper() {
 _list_profiles() {
     echo "kpn", "KPN (NL)"
     echo "kpn", "XS4ALL (NL)"
+    echo "kpn", "Freedom Internet (NL)"
     echo "tweak", "Tweak (NL)"
     echo "solcon", "Solcon (NL)"
     echo "swisscom", "Swisscom (CH)"


### PR DESCRIPTION
Added specific board name and interface options for UniFi Dream Router 7. 
The device has WAN1 and WAN2. This can be used in load balancing and/or failover mode.
The device has 3 physical ports that can be selected for either WAN1 or WAN2.

* eth2: physical switch port 3 (2.5Gbe RJ45)
* eth3: physical switch port 4 (2.5Gbe RJ45)
* eth4: physical SFP+ port

As Freedom Internet Provider user, I've tested the `kpn` profile to be functioning with my setup and added a menu option for Freedom Internet (NL) in the config file. It reuses the kpn profile