### PR TITLE
Change KPN profile: WAN range to 0.0.0.0/0, which is future-proof

### DIFF
--- a/profiles/kpn.profile
+++ b/profiles/kpn.profile
@@ -12,5 +12,5 @@ db_get udm-iptv/wan-port
 db_set udm-iptv/wan-interface "$RET"
 
 db_set udm-iptv/wan-vlan 4
-db_set udm-iptv/wan-ranges "213.75.0.0/16, 217.166.0.0/16, 195.121.0.0/16"
+db_set udm-iptv/wan-ranges "0.0.0.0/0"
 db_set udm-iptv/wan-dhcp-options "-O staticroutes -V IPTV_RG"


### PR DESCRIPTION
This PR changes the WAN address to a more future-proof value, as confimed [here](https://community.kpn.com/kpn-tv-11/ontvangers-blijven-hangen-op-80-na-update-modem-626696).