### PR TITLE
Update Github Actions workflow to use latest Ubuntu image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   build:
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-latest]
     if: ${{ !contains(github.event.head_commit.message, 'skip ci') }}
     steps:
       - name: Checkout Sources
@@ -12,7 +12,7 @@ jobs:
         with:
           path: udm-iptv
       - name: Setup Dependencies
-        run: sudo apt-get install devscripts debhelper
+        run: sudo apt-get install devscripts debhelper build-essential
       - name: Build Package
         run: |
           cd udm-iptv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-latest]
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
@@ -16,7 +16,7 @@ jobs:
           path: udm-iptv
           submodules: recursive
       - name: Setup Dependencies
-        run: sudo apt-get install devscripts debhelper
+        run: sudo apt-get install devscripts debhelper build-essential
       - name: Build Package
         run: |
           cd udm-iptv
@@ -33,7 +33,7 @@ jobs:
             *.dsc
   release:
     name: Publish Release
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-latest]
     needs: build
     steps:
       - name: Checkout Sources
@@ -54,7 +54,7 @@ jobs:
           dpkg-parsechangelog -c 1 -l debian/changelog >> $GITHUB_OUTPUT
           echo "${delimiter}" >> $GITHUB_OUTPUT
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/debian/rules
+++ b/debian/rules
@@ -15,3 +15,9 @@ include /usr/share/dpkg/architecture.mk
 
 %:
 	dh $@
+
+
+override_dh_builddeb:
+	# Force creation of XZ compressed Debian archive. Newer versions of Debian
+	# will default to ZSTD which is not yet available in UniFi OS
+	dh_builddeb -- -Zxz


### PR DESCRIPTION
GitHub Actions is deprecating the Ubuntu 20.04 image used by udm-iptv to build the Debian package. In this commit I'm updating the CI workflows to make use of the latest Ubuntu images.