### PR TITLE
Add support for Bell Canada

### DIFF
--- a/debian/config
+++ b/debian/config
@@ -73,6 +73,7 @@ _list_profiles() {
     echo "vivo", "Vivo SP (BR)"
     echo "posttv", "PostTV (LU)"
     echo "magentatv", "MagentaTV (DE)"
+    echo "bellcanada", "Bell Canada"
 }
 
 # Obtain the board name of the device running the installation script

--- a/debian/config
+++ b/debian/config
@@ -104,6 +104,7 @@ if [ -e $CONFIGFILE ]; then
     db_set udm-iptv/wan-vlan-mac "$IPTV_WAN_VLAN_MAC"
 
     db_set udm-iptv/wan-ranges "$(echo "$IPTV_WAN_RANGES" | tr -s ' ' ',')"
+    db_set udm-iptv/wan-ranges-gw-dest "$([ "$IPTV_WAN_RANGES_GW_DEST" = "true" ] && echo "true" || echo "false")"
     db_set udm-iptv/wan-dhcp "$IPTV_WAN_DHCP"
     db_set udm-iptv/wan-dhcp-options "$IPTV_WAN_DHCP_OPTIONS"
     db_set udm-iptv/wan-static-ip "$IPTV_WAN_STATIC_IP"

--- a/debian/postinst
+++ b/debian/postinst
@@ -59,6 +59,9 @@ fi
 db_get udm-iptv/wan-ranges
 replace_conf "$tmpconf" "IPTV_WAN_RANGES" "$(echo "$RET" | tr ',' ' ')"
 
+db_get udm-iptv/wan-ranges-gw-dest
+replace_conf "$tmpconf" "IPTV_WAN_RANGES_GW_DEST" "$RET"
+
 db_get udm-iptv/wan-dhcp
 if [ "$RET" = "false" ]; then
     replace_conf "$tmpconf" "IPTV_WAN_DHCP" "$RET"

--- a/debian/templates
+++ b/debian/templates
@@ -44,6 +44,11 @@ _Description: IP ranges from which the IPTV traffic originates:
 Type: string
 Default: 213.75.0.0/16, 217.166.0.0/16
 
+Template: udm-iptv/wan-ranges-gw-dest
+_Description: Use WAN ranges as DHCP gateway destinations?
+Type: boolean
+Default: false
+
 Template: udm-iptv/wan-dhcp
 _Description: Obtain IP address for IPTV interface via DHCP?
 Type: boolean

--- a/profiles/bellcanada.profile
+++ b/profiles/bellcanada.profile
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+# Profile for Bell Canada
+#
+# Copyright (C) 2022 Fabian Mastenbroek.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+db_get udm-iptv/wan-port
+db_set udm-iptv/wan-interface "$RET"
+
+db_set udm-iptv/wan-vlan 36
+db_set udm-iptv/wan-ranges "10.2.0.0/16"
+db_set udm-iptv/wan-dhcp true
+db_set udm-iptv/wan-ranges-gw-dest true

--- a/profiles/custom.profile
+++ b/profiles/custom.profile
@@ -62,6 +62,10 @@ while true; do
         if [ "$RET" = true ]; then
             db_set udm-iptv/wan-static-ip ""
             db_input high udm-iptv/wan-dhcp-options || true
+            db_get udm-iptv/wan-ranges
+            if [ -n "$RET" ]; then
+                db_input high udm-iptv/wan-ranges-gw-dest || true
+            fi
         else
             db_input low udm-iptv/wan-static-ip || true
         fi

--- a/udhcpc.hook
+++ b/udhcpc.hook
@@ -84,7 +84,13 @@ routes() {
     else
         local gw=
         for gw in $router; do
-            route_add 0.0.0.0/0 $gw $num && num=$(($num + 1))
+            local dests="0.0.0.0/0"
+            if [ "$IPTV_WAN_RANGES_GW_DEST" = "true" ]; then
+                dests=$IPTV_WAN_RANGES
+            fi
+            for dest in $dests; do
+                route_add $dest $gw $num && num=$(($num + 1))
+            done
         done
     fi
 }


### PR DESCRIPTION
Used the "Bell Canada" name as opposed to "Bell," because there is a different branch of Bell ("Bell Aliant") that I think may have a slightly different IPTV config.

This required adding a variable to allow using the WAN ranges as as the destination for the DHCP gateway as no static routes are specified in the DHCP lease and using the default gateway breaks internet and IPTV on the same LAN.